### PR TITLE
Replacing all go.cd domains with gocd.io domain

### DIFF
--- a/rakelib/bump_version.rake
+++ b/rakelib/bump_version.rake
@@ -45,7 +45,7 @@ task :bump_version do
 
     next_version_data = {
       version: next_version,
-      location: "https://plugin-api.go.cd/#{next_version}/",
+      location: "https://plugin-api.gocd.io/#{next_version}/",
       type: "next"
     }
 

--- a/source/elastic-agents/index.html.md.erb
+++ b/source/elastic-agents/index.html.md.erb
@@ -3,8 +3,8 @@ title: GoCD Elastic Agent Plugin API Reference
 
 toc_footers:
   - <a href='https://github.com/gocd/plugin-api.go.cd'>Edit this guide on GitHub</a>
-  - <a href='https://api.go.cd'>GoCD API Documentation</a>
-  - <a href='https://docs.go.cd'>GoCD User Documentation</a>
+  - <a href='https://api.gocd.io'>GoCD API Documentation</a>
+  - <a href='https://docs.gocd.io'>GoCD User Documentation</a>
 
 search: true
 ---

--- a/source/includes/elastic-agents/_010-introduction.md.erb
+++ b/source/includes/elastic-agents/_010-introduction.md.erb
@@ -25,8 +25,8 @@ then brought down when not needed. This feature should enable a more flexible an
 ## Current process of handling agents
 
 Agents are currently started manually or automatically by scripts written by users. They are registered to the GoCD
-server manually, on the [agents page](https://docs.go.cd/current/navigation/agents_page.html) or
-automatically, using [auto-registration](https://docs.go.cd/current/advanced_usage/agent_auto_register.html).
+server manually, on the [agents page](https://docs.gocd.io/current/navigation/agents_page.html) or
+automatically, using [auto-registration](https://docs.gocd.io/current/advanced_usage/agent_auto_register.html).
 
 Idle agents, after registration with the server, continuously poll the server, asking for jobs to run. When a stage is
 triggered, the jobs that need to be started are identified by the server. Suitable jobs are assigned to agents
@@ -83,7 +83,7 @@ The plugin decides whether to assign an agent to a job, or to start another agen
 1. When a job is [scheduled](#glossary-schedule), if its job configuration contains a elasticProfileId, the job is
    not considered for normal [assignment](#glossary-assign) as described in the previous section.
 2. The  plugin corresponding for that job elasticProfileId is contacted
-   (to [create an agent](https://plugin-api.go.cd/current/elastic-agents/#create-agent)),
+   (to [create an agent](https://plugin-api.gocd.io/current/elastic-agents/#create-agent)),
    along with the corresponding profile configuration for which this assignment needs to be made.
 3. At this point the plugin may, at its discretion, create an agent or not.
    1. If it sees that there are no idle agents that satisfy the profile, it may choose to spin a new agent.
@@ -94,7 +94,7 @@ The plugin decides whether to assign an agent to a job, or to start another agen
    it to choose, again.
 5. When an elastic-agent pings the server for work, and if there is a job that requires an elastic-agent, then the
    corresponding plugin for that job is contacted (to check if the server
-   [should assign work](https://plugin-api.go.cd/current/elastic-agents/#should-assign-work) to the agent), along with the
+   [should assign work](https://plugin-api.gocd.io/current/elastic-agents/#should-assign-work) to the agent), along with the
    profile configuration for which this assignment needs to be made.
 
 <aside class='notice'>

--- a/source/includes/elastic-agents/_021-create-agent.md
+++ b/source/includes/elastic-agents/_021-create-agent.md
@@ -65,8 +65,8 @@ The request body will contain the following JSON elements:
 
 | Key                 | Type     | Description |
 | ------------------- | -------- | ----------- |
-| `auto_register_key` | `String` | The key that an agent should use, if it should be auto-registered with the server. The plugin is expected to use the key to create an appropriate `autoregister.properties` file on the agent instance, before it starts the agent process. See the [auto-register documentation](https://docs.go.cd/current/advanced_usage/agent_auto_register.html) for more information. |
-| `environment`       | `String` | The `environment` that this job belongs to. Agents are expected to auto-register using this environment so that they can be assigned to the correct job. See the [environments section](https://docs.go.cd/current/introduction/concepts_in_go.html#environment) to know more about environments. |
+| `auto_register_key` | `String` | The key that an agent should use, if it should be auto-registered with the server. The plugin is expected to use the key to create an appropriate `autoregister.properties` file on the agent instance, before it starts the agent process. See the [auto-register documentation](https://docs.gocd.io/current/advanced_usage/agent_auto_register.html) for more information. |
+| `environment`       | `String` | The `environment` that this job belongs to. Agents are expected to auto-register using this environment so that they can be assigned to the correct job. See the [environments section](https://docs.gocd.io/current/introduction/concepts_in_go.html#environment) to know more about environments. |
 | `properties`        | `Object` | Jobs that require elastic agents, will have an `<agentConfig/>` element on it. This object represents the key value pairs that form this configuration. |
 
 <p class='response-code-heading'>Response code</p>

--- a/source/includes/elastic-agents/_022-should-assign-work.md
+++ b/source/includes/elastic-agents/_022-should-assign-work.md
@@ -64,7 +64,7 @@ The request body will contain the following JSON elements:
 
 | Key                 | Type     | Description |
 | ------------------- | -------- | ----------- |
-| `environment`       | `String` | The `environment` that this job belongs to. See the [environments section](https://docs.go.cd/current/introduction/concepts_in_go.html#environment) to know more about environments. |
+| `environment`       | `String` | The `environment` that this job belongs to. See the [environments section](https://docs.gocd.io/current/introduction/concepts_in_go.html#environment) to know more about environments. |
 | `agent`             | `Object` | An object describing the [elastic agent](#elastic-agent-object). |
 | `properties`        | `Object` | Jobs that require elastic agents, will have an `<agentConfig/>` element on it. This object represents the key value pairs that form this configuration. |
 

--- a/source/includes/elastic-agents/_052-disable-agents.md
+++ b/source/includes/elastic-agents/_052-disable-agents.md
@@ -44,7 +44,7 @@ public class DockerPlugin implements GoPlugin {
 }
 ```
 
-Before a plugin terminates an agent instance, it must first disable it in order to prevent jobs from being assigned to it. This call is the equivalent of setting `isDisabled` on an `<agent/>` element in the config XML. More information about the agent config here, can be found in the [configuration reference](https://docs.go.cd/current/configuration/configuration_reference.html#agent).
+Before a plugin terminates an agent instance, it must first disable it in order to prevent jobs from being assigned to it. This call is the equivalent of setting `isDisabled` on an `<agent/>` element in the config XML. More information about the agent config here, can be found in the [configuration reference](https://docs.gocd.io/current/configuration/configuration_reference.html#agent).
 
 Agents in any state can be disabled, this will prevent jobs from being assigned to it. Any jobs the agent is running will eventually complete.
 

--- a/source/includes/elastic-agents/_053-delete-agents.md
+++ b/source/includes/elastic-agents/_053-delete-agents.md
@@ -50,7 +50,7 @@ public class DockerPlugin implements GoPlugin {
 }
 ```
 
-Before the delete-agent message is sent to the server, the plugin MUST ensure that the agent is terminated. This call is the equivalent of removing the `<agent/>` element in the config XML. More information about the agent config here, can be found in the [configuration reference](https://docs.go.cd/current/configuration/configuration_reference.html#agent).
+Before the delete-agent message is sent to the server, the plugin MUST ensure that the agent is terminated. This call is the equivalent of removing the `<agent/>` element in the config XML. More information about the agent config here, can be found in the [configuration reference](https://docs.gocd.io/current/configuration/configuration_reference.html#agent).
 
 <aside class="notice">
   <strong>Important:</strong> Before an agent is terminated, it is recommended to ensure that it is first <a href='#disable-agents'>disabled</a> and that the <code>agent_state</code> is <code>Idle</code>. This will ensure that any jobs that an agent is running are completed.

--- a/source/includes/shared/_get-plugin-settings.md.erb
+++ b/source/includes/shared/_get-plugin-settings.md.erb
@@ -78,7 +78,7 @@ The server is expected to return status `200` if it could process the request.
 
 ```json
 {
-  "server_url": "https://build.go.cd",
+  "server_url": "https://build.gocd.io",
   "username": "view",
   "password": "password"
 }

--- a/source/index.html.md
+++ b/source/index.html.md
@@ -3,8 +3,8 @@ title: GoCD Plugin API Reference
 
 toc_footers:
   - <a href='https://github.com/gocd/plugin-api.go.cd'>Edit this guide on GitHub</a>
-  - <a href='https://api.go.cd'>GoCD API Documentation</a>
-  - <a href='https://docs.go.cd'>GoCD User Documentation</a>
+  - <a href='https://api.gocd.io'>GoCD API Documentation</a>
+  - <a href='https://docs.gocd.io'>GoCD User Documentation</a>
 
 includes:
   - introduction

--- a/source/notifications/index.html.md.erb
+++ b/source/notifications/index.html.md.erb
@@ -3,8 +3,8 @@ title: GoCD Notification Plugin API Reference
 
 toc_footers:
   - <a href='https://github.com/gocd/plugin-api.go.cd'>Edit this guide on GitHub</a>
-  - <a href='https://api.go.cd'>GoCD API Documentation</a>
-  - <a href='https://docs.go.cd'>GoCD User Documentation</a>
+  - <a href='https://api.gocd.io'>GoCD API Documentation</a>
+  - <a href='https://docs.gocd.io'>GoCD User Documentation</a>
 
 search: true
 ---

--- a/source/tasks/index.html.md.erb
+++ b/source/tasks/index.html.md.erb
@@ -3,8 +3,8 @@ title: GoCD Task Plugin API Reference
 
 toc_footers:
   - <a href='https://github.com/gocd/plugin-api.go.cd'>Edit this guide on GitHub</a>
-  - <a href='https://api.go.cd'>GoCD API Documentation</a>
-  - <a href='https://docs.go.cd'>GoCD User Documentation</a>
+  - <a href='https://api.gocd.io'>GoCD API Documentation</a>
+  - <a href='https://docs.gocd.io'>GoCD User Documentation</a>
 
 search: true
 ---


### PR DESCRIPTION
Script I used to do this migration

```
# For https://github.com/gocd/plugin-api.go.cd
ls -d */ | xargs -IDIR egrep -lRZ '\.go\.cd' DIR | xargs -IFILE sed -i ""  -e 's/\.go\.cd/\.gocd.io/g'  FILE
## Fix the Github urls from the above changes
ls -d */ | xargs -IDIR egrep -lRZ '\/gocd\/plugin-api\.gocd\.io' DIR | xargs -IFILE sed -i "" -e 's/\/gocd\/plugin-api\.gocd\.io/\/gocd\/plugin-api\.go\.cd/g' FILE
```

Ref - https://github.com/gocd/gocd/issues/3052