### PR TITLE
Added SCM plugin api docs

### DIFF
--- a/source/includes/_introduction.md
+++ b/source/includes/_introduction.md
@@ -1,0 +1,16 @@
+# Introduction
+
+Welcome to the GoCD Plugin API! You can use this API to implement GoCD plugins for
+[SCMs](scm),
+[tasks](tasks),
+[notifications](notifications),
+authentication,
+package repositories,
+[elastic agents](elastic-agents),
+[authorization](authorization) and
+[config repositories](config-repo).
+
+Plugins, as the name implies, help in extending the functionality of GoCD. GoCD publishes a list of extension points for
+which plugins can be provided. An extension point published by the GoCD - defines the interface and the lifecycle that
+governs the respective plugin. At present only Java based extension points and plugins are supported by GoCD, but the
+interface is simple enough for anyone to build plugins in other languages using a simple HTTP bridge.

--- a/source/includes/scm/_010-introduction.md.erb
+++ b/source/includes/scm/_010-introduction.md.erb
@@ -1,0 +1,18 @@
+# SCM Material Plugins
+
+The SCM extension endpoint allows plugin authors to extend GoCD and integrate it with other SCMs.
+
+GoCD's user documentation has an overview of SCM material plugins. Please see [that](https://docs.gocd.org/current/extension_points/scm_extension.html).
+
+
+[A sample SCM material plugin - JGit](https://github.com/gocd/go-plugins/tree/master/plugins-for-tests/test-scm-plugin)
+
+## Extension information
+
+<p class='attributes-table-follows'></p>
+
+|                            |                              |
+| -------------------------- | ---------------------------- |
+| **Availability**           |  GoCD version 15.1.0 onwards |
+| **Extension Name**         | `scm`                        |
+| **Extension API Version**  | `1.0`                        |

--- a/source/includes/scm/_020-request-from-server.md
+++ b/source/includes/scm/_020-request-from-server.md
@@ -1,0 +1,11 @@
+# Requests from the GoCD server
+
+In order to implement a SCM extension endpoint the following messages must be implemented by the plugin.
+
+* [SCM Configuration](#scm-configuration)
+* [SCM View](#scm-view)
+* [Validate SCM Configuration](#validate-scm-configuration)
+* [Check SCM Connection](#check-scm-connection)
+* [Latest SCM Revision](#latest-revision)
+* [Latest SCM Revisions Since](#latest-revisions-since)
+* [Checkout](#checkout)

--- a/source/includes/scm/_030-scm-configuration.md
+++ b/source/includes/scm/_030-scm-configuration.md
@@ -1,0 +1,53 @@
+## SCM Configuration
+ 
+This message is sent by the server, when it wants to know what properties need to be stored in the configuration, for this plugin and this SCM.
+
+The plugin will receive request with following information.
+
+<p class='request-name-heading'>Request name</p>
+
+`scm-configuration`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+The server will not provide request body.
+
+> Example response body
+
+```json
+{
+    "SCM_URL": {
+        "display-name": "SCM URL",
+        "display-order": "0"
+    },
+    "USERNAME": {
+        "part-of-identity": false,
+        "required": false,
+        "display-name": "User",
+        "display-order": "1"
+    },
+    "PASSWORD": {
+        "secure": true,
+        "part-of-identity": false,
+        "required": false,
+        "display-name": "Password",
+        "display-order": "2"
+    }
+}
+```
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+The plugin is expected to return an object containing the configuration property along with [scm configuration object](#the-scm-configuration-response-object)

--- a/source/includes/scm/_040-scm-view.md
+++ b/source/includes/scm/_040-scm-view.md
@@ -1,0 +1,36 @@
+## SCM View
+
+This message is sent by the server, to get a template to show to the user, to allow information about a SCM to be provided.
+
+<p class='request-name-heading'>Request name</p>
+
+`scm-view`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+The server will not provide request body.
+
+> Example response body
+
+```json
+{
+   "displayValue": "JGit",
+   "template": "<div class=\"form_item_block\"><label>Message:<span class=\"asterisk\">*</span></label><input type=\"text\" ng-model=\"message\" ng-required=\"true\"></div>"
+}
+```
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+The plugin is expected to return an object containing the view rendering information [scm view response object](#the-scm-view-response-object)

--- a/source/includes/scm/_045-validate-scm-configuration.md
+++ b/source/includes/scm/_045-validate-scm-configuration.md
@@ -1,0 +1,60 @@
+## Validate SCM Configuration
+
+> Example request body
+
+```json
+{
+    "scm-configuration": {
+        "SCM_URL": {
+            "value": "http://localhost.com"
+        },
+        "USERNAME": {
+            "value": "user"
+        },
+        "PASSWORD": {
+            "value": "password"
+        }
+    }
+}
+```
+
+The plugin will receive request with following information.
+
+<p class='request-name-heading'>Request name</p>
+
+`validate-scm-configuration`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+This contains information about the SCM configuration provided by the user. The keys in the maps correspond to the keys provided by the plugin, as a part of the response to ["SCM Configuration"](#scm-configuration) message.
+
+> Example response body
+
+```json
+[
+    {
+        "key": "SCM_URL",
+        "message": "SCM URL not specified"
+    },
+    {
+        "key": "RANDOM",
+        "message": "Unsupported key(s) found : RANDOM. Allowed key(s) are : SCM_URL, USERNAME, PASSWORD"
+    }
+]
+```
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+The plugin is expected to send a response, which contains a list of errors in the SCM configuration, one message for every key in the request. It can also send an empty list, ie [], if the configuration is valid.

--- a/source/includes/scm/_050-check-scm-connection.md
+++ b/source/includes/scm/_050-check-scm-connection.md
@@ -1,0 +1,56 @@
+## Check SCM Connection
+
+> Example request body
+
+```json
+{
+    "scm-configuration": {
+        "SCM_URL": {
+            "value": "http://localhost.com"
+        },
+        "USERNAME": {
+            "value": "user"
+        },
+        "PASSWORD": {
+            "value": "password"
+        }
+    }
+}
+```
+ 
+The plugin will receive request with following information.
+
+<p class='request-name-heading'>Request name</p>
+
+`check-scm-connection`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+This contains information about the SCM configuration provided by the user. The keys in the maps correspond to the keys provided by the plugin, as a part of the response to ["SCM Configuration"](#scm-configuration) message.
+
+> Example response body
+
+```json
+{
+    "status": "success",
+    "messages": [
+        "Successfully connected to SCM URL provided"
+    ]
+}
+```
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+The plugin is expected to send a response, which contains a status ("success" or "failure"), and a list of error messages. This represents whether a connection was successfully made, to the SCM specified in the request.

--- a/source/includes/scm/_055-latest-revision.md
+++ b/source/includes/scm/_055-latest-revision.md
@@ -1,0 +1,79 @@
+## Latest Revision
+
+> Example request body
+
+```json
+{
+    "scm-configuration": {
+        "SCM_URL": {
+            "value": "http://localhost.com"
+        },
+        "USERNAME": {
+            "value": "user"
+        },
+        "PASSWORD": {
+            "value": "password"
+        }
+    },
+    "flyweight-folder": "/var/lib/go-server/pipelines/flyweight-for-this-material"
+}
+```
+ 
+The plugin will receive request with following information.
+
+<p class='request-name-heading'>Request name</p>
+
+`latest-revision`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+This contains information about the SCM configuration provided by the user. The keys in the maps correspond to the keys provided by the plugin, as a part of the response to ["SCM Configuration"](#scm-configuration) message.
+
+<aside class="notice">
+  <strong>Note:</strong> It is prudent to validate these details before using them, because direct editing of GoCD's configuration XML file does not cause <a href="#validate-scm-configuration">Validate SCM Configuration</a> to be sent to the plugin. So, the information sent to this call might not be validated by the plugin.
+</aside>
+
+> Example response body
+
+```json
+{
+    "revision": {
+        "revision": "revision-1",
+        "timestamp": "2011-07-14T19:43:37.100Z",
+        "user": "some-user",
+        "revisionComment": "comment",
+        "data": {
+            "dataKeyOne": "data-value-one",
+            "dataKeyTwo": "data-value-two"
+        },
+        "modifiedFiles": [
+            {
+                "fileName": "file-1",
+                "action": "added"
+            }
+        ]
+    },
+    "scm-data": {
+        "dataKeyOne": "data-value-one",
+        "dataKeyTwo": "data-value-two"
+    }
+}
+```
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+The plugin is expected to send a response, which contains information about the latest revision it can find of the SCM specified by the information in the request. It can send an empty response ({}) to specify that it could not find a revision.
+
+Almost all the fields expected in this response are explained in this [part of the user documentation](https://docs.gocd.org/current/extension_points/scm_extension.html#scm-information-display). The extra map, named "data" in the response, can be filled with custom key-value pairs, which will be made available to the agent, as environment variables, when a job contains this plugin as a material.

--- a/source/includes/scm/_060-latest-revisions-since.md
+++ b/source/includes/scm/_060-latest-revisions-since.md
@@ -1,0 +1,95 @@
+## Latest Revisions Since
+
+> Example request body
+
+```json
+{
+    "scm-configuration": {
+        "SCM_URL": {
+            "value": "http://localhost.com"
+        },
+        "USERNAME": {
+            "value": "user"
+        },
+        "PASSWORD": {
+            "value": "password"
+        }
+    },
+    "scm-data": {
+        "dataKeyOne": "data-value-one",
+        "dataKeyTwo": "data-value-two"
+    },
+    "flyweight-folder": "/var/lib/go-server/pipelines/flyweight-for-this-material",
+    "previous-revision": {
+        "revision": "revision-1",
+        "timestamp": "2011-07-14T19:43:37.100Z",
+        "data": {
+          "dataKeyOne": "data-value-one",
+          "dataKeyTwo": "data-value-two"
+        }
+    }
+}
+```
+
+The plugin will receive request with following information.
+
+<p class='request-name-heading'>Request name</p>
+
+`latest-revisions-since`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+This request is very similar to the request of the ["Latest Revision" message](#latest-revision). This contains information about the SCM configuration provided by the user. The keys in the maps correspond to the keys provided by the plugin, as a part of the response to ["SCM Configuration"](#scm-configuration) messages.
+
+Along with that information, this request contains information about the previous revision of the SCM that GoCD knows about. Compare the "previous-revision" data of the example request shown below, with the response of the ["Latest Revision" message](#latest-revision) to understand this.
+
+<aside class="notice">
+  <strong>Note:</strong> It is prudent to validate these details before using them, because direct editing of GoCD's configuration XML file does not cause <a href="#validate-scm-configuration">Validate SCM Configuration</a> to be sent to the plugin. So, the information sent to this call might not be validated by the plugin.
+</aside>
+
+> Example response body
+
+```json
+{
+    "revisions" : [
+        {
+            "revision": "revision-2",
+            "timestamp": "2011-07-14T19:45:37.100Z",
+            "user": "some-user",
+            "revisionComment": "comment 2",
+            "data": {
+                "dataKeyOne": "data-value-one-1",
+                "dataKeyTwo": "data-value-two-2"
+            },
+            "modifiedFiles": [
+                {
+                    "fileName": "file-2",
+                    "action": "modified"
+                }
+            ]
+        }
+    ],
+    "scm-data": {
+        "dataKeyOne": "data-value-one",
+        "dataKeyTwo": "data-value-three"
+    }
+}
+```
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+Just as with the "Latest Revision" message, the plugin is expected to send a response, which contains information about the latest revision it can find of the SCM specified by the information in the request. The difference here, is that it needs to find a revisions of the SCM which is greater than the one specified in the request - previous-revision. It can send an empty response ({}) to specify that it could not find revisions (for instance, if there has been no change, and the latest revision is still the one specified in the request).
+
+Almost all the fields expected in this response are explained in this [part of the user documentation](https://docs.gocd.org/current/extension_points/scm_extension.html#scm-information-display). The extra map, named "data" in the response, can be filled with custom key-value pairs, which will be made available to the agent, as environment variables, when a job contains this plugin as a material.

--- a/source/includes/scm/_065-checkout.md
+++ b/source/includes/scm/_065-checkout.md
@@ -1,0 +1,67 @@
+## Checkout
+
+> Example request body
+
+```json
+{
+    "scm-configuration": {
+        "SCM_URL": {
+            "value": "http://localhost.com"
+        },
+        "USERNAME": {
+            "value": "user"
+        },
+        "PASSWORD": {
+            "value": "password"
+        }
+    },
+    "destination-folder": "/var/lib/go-agent/pipelines/pipeline-name/destination",
+    "revision": {
+        "revision": "revision-1",
+        "timestamp": "2011-07-14T19:43:37.100Z",
+        "data": {
+          "dataKeyOne": "data-value-one",
+          "dataKeyTwo": "data-value-two"
+        }
+    }   
+}
+```
+ 
+The plugin will receive request with following information.
+
+<p class='request-name-heading'>Request name</p>
+
+`checkout`
+
+<p class='request-body-heading'>Request parameters</p>
+
+The server will not provide any parameters.
+
+<p class='request-body-heading'>Request headers</p>
+
+The server will not provide any headers.
+
+<p class='request-body-heading'>Request body</p>
+
+This contains information about the SCM configuration provided by the user. The keys in the maps correspond to the keys provided by the plugin, as a part of the response to ["SCM Configuration"](#scm-configuration) message.
+
+
+> Example response body
+
+```json
+{
+    "status": "success",
+    "messages": [
+        "Successfully checked out to SCM revision provided"
+    ]
+}
+```
+
+
+<p class='response-code-heading'>Response code</p>
+
+The plugin is expected to return status `200` if it can understand the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+The plugin is expected to send a response, which contains a status ("success" or "failure"), and a list of error messages. This represents whether a checkout was successfully made, to the SCM specified in the request.

--- a/source/includes/scm/_090-object-descriptions.md.erb
+++ b/source/includes/scm/_090-object-descriptions.md.erb
@@ -1,0 +1,47 @@
+# Request/Response JSON Objects
+
+<%
+json = {
+    'SCM_URL'=> {
+        'display-name'=> 'SCM URL',
+        'display-order'=> '0'
+    },
+    'USERNAME'=> {
+        'part-of-identity'=> false,
+        'required'=> false,
+        'display-name'=> 'User',
+        'display-order'=> '1'
+    },
+    'PASSWORD'=> {
+        'secure'=> true,
+        'part-of-identity'=> false,
+        'required'=> false,
+        'display-name'=> 'Password',
+        'display-order'=> '2'
+    }
+}
+%>
+
+<%=
+describe_sub_object 'The SCM Configuration Response Object', json: json, html_id: 'the-scm-configuration-response-object' do
+  __add_property('default-value', 'String', 'A value to be used as the default if the user provides no value.')
+  __add_property('secure', 'Boolean', 'If the value should be stored in an encrypted form in the `cruise-config.xml` file.')
+  __add_property('required', 'Boolean', 'Whether the field is required.')
+end
+%>
+
+<%
+json = {
+  displayValue: 'SCM name',
+  template: '<div class="form_item_block">...</div>'
+}
+%>
+
+<%=
+describe_sub_object 'The SCM View Response Object', json: json, html_id: 'the-scm-view-response-object' do
+  displayValue String, 'The name of the scm that should be rendered in the view'
+  template 'String',   'A string containing an HTML AngularJS based view.'
+end
+%>
+
+<%= partial 'includes/shared/angular-templates.md' %>

--- a/source/scm/index.html.md.erb
+++ b/source/scm/index.html.md.erb
@@ -1,0 +1,15 @@
+---
+title: GoCD SCM Plugin API Reference
+
+toc_footers:
+  - <a href='https://github.com/gocd/plugin-api.go.cd'>Edit this guide on GitHub</a>
+  - <a href='https://api.gocd.org'>GoCD API Documentation</a>
+  - <a href='https://docs.gocd.org'>GoCD User Documentation</a>
+
+description: The objective of this guide is to explain how to write a SCM material plugin for GoCD
+keywords: scm material, json api, message based api, gocd plugin, gocd plugins, scm configuration
+
+search: true
+---
+
+<%= render_all_sub_topics('scm') %>


### PR DESCRIPTION
Moved [SCM extension doc](https://developer.gocd.org/current/writing_go_plugins/scm_material/scm_material_plugin_overview.html) from developer.gocd.org to here.