### PR TITLE
some style fixes for consistency:

### DIFF
--- a/source/includes/analytics/_021_capabilities.md
+++ b/source/includes/analytics/_021_capabilities.md
@@ -12,7 +12,7 @@ Server sends request with `Empty` request body.
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body —
+> An example response body:
 
 ```json
 {

--- a/source/includes/analytics/_023_get_analytics.md
+++ b/source/includes/analytics/_023_get_analytics.md
@@ -13,7 +13,7 @@ The `view_path` should refer to the HTML which should be part of the [static ass
 
 <p class='request-body-heading'>Request body</p>
 
-> An example request body -
+> An example request body:
 
 ```json
 {
@@ -27,16 +27,16 @@ The `view_path` should refer to the HTML which should be part of the [static ass
 
 <p class='attributes-table-follows'></p>
 
-| Key            | Type     | Description                                                                                |
-|----------------|----------|--------------------------------------------------------------------------------------------|
-| `type`         | `String` | The type of the analytics as defined in the [Plugin Capabilities](#get-plugin-capabilities)|
-| `id`           | `String` | The id of the analytics as defined in the [Plugin Capabilities](#get-plugin-capabilities)  |
+| Key            | Type     | Description                                                                                 |
+|----------------|----------|---------------------------------------------------------------------------------------------|
+| `type`         | `String` | The type of the analytics as defined in the [Plugin Capabilities](#get-plugin-capabilities).|
+| `id`           | `String` | The id of the analytics as defined in the [Plugin Capabilities](#get-plugin-capabilities).  |
 | `params`       | `Object` | This is a hash of optional params the plugin would require to generate analytics. For analytics of type `pipeline`, GoCD will send the pipeline name as a param `pipeline_name`. |
 
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body —
+> An example response body:
 
 ```json
 {

--- a/source/includes/analytics/_024_plugin-settings_changed.md
+++ b/source/includes/analytics/_024_plugin-settings_changed.md
@@ -12,7 +12,7 @@ Every time the plugin settings change, GoCD will send this message to the plugin
 
 The request body will be a JSON which will be a map of the plugin settings.
 
-> An example request body
+> An example request body:
 
 ```json
 {

--- a/source/includes/analytics/_040_javascript_messages.md
+++ b/source/includes/analytics/_040_javascript_messages.md
@@ -75,6 +75,18 @@ This sets up the receiving endpoint for messages from GoCD. The `version` parame
 
 ## The Transport Object
 
+> Example snippet:
+
+```javascript
+AnalyticsEndpoint.onInit(function(initialData, transport) {
+  var params = { url: "https://google.com" };
+  transport.request("link-external", params).
+    done(function(data) { console.log("success! received: " + JSON.stringify(data)); }).
+    fail(function(errors) { console.log("failed due to: " + JSON.stringify(errors)); }).
+    always(function() { console.log("all done here."); });
+});
+```
+
 The `Transport` object provides an AJAX-like API to facilitate communication with GoCD. It provides a chainable callback setup, similar to
 `jQuery.ajax` handlers. It has a `request` method, which takes two parameters:
 
@@ -84,9 +96,9 @@ The `Transport` object provides an AJAX-like API to facilitate communication wit
 | parameters | A parameter object which depends on the `requestKey` used.                                                                |
 
 
-The `request method `returns a chainable object to set up `done`, `fail`, and `always` callbacks:
+The `request() method` returns a chainable object to set up `done`, `fail`, and `always` callbacks:
 
-1. `done(function(data) {})`: fires upon successful response from GoCD. Similar to [done() in jQuery](https://api.jquery.com/deferred.done/).
-2. `fail(function(errors) {})`: fires upon error response from GoCD. Similar to [fail() in jQuery](https://api.jquery.com/deferred.fail/)
-3. `always(function() {})`: fires after response is received, regardless of success/failure. executes after `done()` or `fail()`. Similar to
+1. `done(function(data) {})`: Fires upon successful response from GoCD. Similar to [done() in jQuery](https://api.jquery.com/deferred.done/).
+2. `fail(function(errors) {})`: Fires upon error response from GoCD. Similar to [fail() in jQuery](https://api.jquery.com/deferred.fail/)
+3. `always(function() {})`: Fires after response is received, regardless of success/failure. Executes after `done()` or `fail()`. Similar to
    [always() in jQuery](https://api.jquery.com/deferred.always/).

--- a/source/includes/analytics/_043_link_to.md
+++ b/source/includes/analytics/_043_link_to.md
@@ -58,7 +58,7 @@ To link to the job details page, the parameter object should contain these keys:
 
 ### Request key: `link-to` pipeline instance page
 
-> An example message from iframe to parent window to link to pipeline instance page -
+> An example message from iframe to parent window to link to pipeline instance page:
 
 ```html
 <html>

--- a/source/includes/analytics/_044_link_external.md
+++ b/source/includes/analytics/_044_link_external.md
@@ -36,6 +36,6 @@ link to a page outside of GoCD. The parent window will open the page in a new ta
 
 The parameter object should contain:
 
-| Key   | Description                          |
-|-------|--------------------------------------|
-| `url` | The URL that should be navigated to. |
+| Key   | Description             |
+|-------|-------------------------|
+| `url` | The URL to navigate to. |

--- a/source/includes/authorization/_022-capabilities.md
+++ b/source/includes/authorization/_022-capabilities.md
@@ -12,7 +12,7 @@ Server sends request with `Empty` request body.
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body —
+> An example response body:
 
 ```json
 {

--- a/source/includes/authorization/_023-get-config-metadata.md
+++ b/source/includes/authorization/_023-get-config-metadata.md
@@ -12,7 +12,7 @@ The server will not provide a request body.
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body
+> An example response body:
 
 ```json
 [

--- a/source/includes/authorization/_024-get-config-view.md.erb
+++ b/source/includes/authorization/_024-get-config-view.md.erb
@@ -16,7 +16,7 @@ The plugin is expected to return status `200` if it can understand the request.
 
 <p class='response-body-heading'>Response Body</p>
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/authorization/_026-authenticate-user.md
+++ b/source/includes/authorization/_026-authenticate-user.md
@@ -59,7 +59,7 @@ GoCD forces a perodic re-authentication of users, this is to ensure any changes 
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body —
+> An example response body:
 
 ```json
 {

--- a/source/includes/authorization/_028-get-role-metadata.md
+++ b/source/includes/authorization/_028-get-role-metadata.md
@@ -12,7 +12,7 @@ The server will not provide a request body.
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body
+> An example response body:
 
 ```json
 [

--- a/source/includes/authorization/_029-get-role-view.md.erb
+++ b/source/includes/authorization/_029-get-role-view.md.erb
@@ -18,7 +18,7 @@ The plugin is expected to return status `200` if it can understand the request.
 
 A JSON [settings view object](#the-get-settings-view-object)
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/authorization/_032_authorization_server_url.md
+++ b/source/includes/authorization/_032_authorization_server_url.md
@@ -35,7 +35,7 @@ This is a message that a web based plugin should implement. A web based plugin u
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body —
+> An example response body:
 
 
 ```json

--- a/source/includes/elastic-agents/_016-capabilities.md
+++ b/source/includes/elastic-agents/_016-capabilities.md
@@ -12,7 +12,7 @@ Server sends request with `Empty` request body.
 
 <p class='response-code-heading'>Response Body</p>
 
-> An example response body —
+> An example response body:
 
 ```json
 {

--- a/source/includes/elastic-agents/_029-get-profile-view.md.erb
+++ b/source/includes/elastic-agents/_029-get-profile-view.md.erb
@@ -18,7 +18,7 @@ The plugin is expected to return status `200` if it can understand the request.
 
 A JSON [settings view object](#the-get-settings-view-object)
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/elastic-agents/_035-get-agent-status-report.md.erb
+++ b/source/includes/elastic-agents/_035-get-agent-status-report.md.erb
@@ -40,7 +40,7 @@ The plugin is expected to return status `200` JSON object of view and in followi
 
 <p class='response-body-heading'>Response Body</p>
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/elastic-agents/_036-get-plugin-status-report.md.erb
+++ b/source/includes/elastic-agents/_036-get-plugin-status-report.md.erb
@@ -16,7 +16,7 @@ The plugin is expected to return status `200` JSON object of view and in followi
 
 <p class='response-body-heading'>Response Body</p>
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/notifications/_021-notifications-interested-in.md
+++ b/source/includes/notifications/_021-notifications-interested-in.md
@@ -23,7 +23,7 @@ Currently supported notifications include:
 
 * `stage-status`. See [stage status changed](#stage-status-changed) for the information that the plugin receives on stage status change.
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/shared/_add-server-health-messages.erb
+++ b/source/includes/shared/_add-server-health-messages.erb
@@ -72,7 +72,7 @@ Version: `1.0`
 
 <p class='request-body-heading'>Request body</p>
 
-> An example request body
+> An example request body:
 
 ```json
 [
@@ -103,7 +103,7 @@ The server is expected to return status `200` if it could process the request. I
 
 <p class='response-body-heading'>Response Body</p>
 
-> An example response body for a failure
+> An example response body for a failure:
 
 ```json
 {

--- a/source/includes/shared/_angular-templates.md
+++ b/source/includes/shared/_angular-templates.md
@@ -8,7 +8,7 @@ GoCD uses Angular JS as its template engine for the plugin UI. This allows plugi
 
 #### Getting started with AngularJS based templates
 
-> Given a configuration —
+> Given a configuration:
 
 ```xml
 <configuration>
@@ -19,7 +19,7 @@ GoCD uses Angular JS as its template engine for the plugin UI. This allows plugi
 </configuration>
 ```
 
-> This gets converted into the following JSON representation in the browser —
+> This gets converted into the following JSON representation in the browser:
 
 ```json
 {
@@ -27,7 +27,7 @@ GoCD uses Angular JS as its template engine for the plugin UI. This allows plugi
 }
 ```
 
-> The AngularJS template is expected to bind to the JSON object shown above —
+> The AngularJS template is expected to bind to the JSON object shown above:
 
 ```html
 <div class="form_item_block">

--- a/source/includes/shared/_get-icon.md.erb
+++ b/source/includes/shared/_get-icon.md.erb
@@ -16,7 +16,7 @@ The plugin is expected to return status `200` if it can understand the request.
 
 <p class='response-body-heading'>Response Body</p>
 
-> An example plugin response body
+> An example plugin response body:
 
 ```json
 {

--- a/source/includes/shared/_get-plugin-settings.md.erb
+++ b/source/includes/shared/_get-plugin-settings.md.erb
@@ -58,7 +58,7 @@ This messages allows a plugin to query the server to get the user configured set
 
 <p class='request-body-heading'>Request body</p>
 
-> An example request body
+> An example request body:
 
 ```json
 {
@@ -74,7 +74,7 @@ The server is expected to return status `200` if it could process the request.
 
 <p class='response-body-heading'>Response Body</p>
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/shared/_get-server-info.md.erb
+++ b/source/includes/shared/_get-server-info.md.erb
@@ -24,7 +24,7 @@ The server is expected to return status `200` if it could process the request.
 
 The plugin will provide a [server info](#the-server-info-object) object.
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/shared/_get-settings-view.md
+++ b/source/includes/shared/_get-settings-view.md
@@ -18,7 +18,7 @@ The plugin is expected to return status `200` if it can understand the request.
 
 A JSON [settings view object](#the-get-settings-view-object)
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/shared/_plugin-structure.md.erb
+++ b/source/includes/shared/_plugin-structure.md.erb
@@ -4,7 +4,7 @@ Plugins in GoCD are implemented in Java and packaged as a JAR file.
 
 ## Structure of a GoCD Plugin
 
-> A plugin for GoCD is a JAR file with the following structure
+> A plugin for GoCD is a JAR file with the following structure:
 
 ```
 plugin.jar
@@ -22,17 +22,17 @@ plugin.jar
     \-- dependency-2.jar
 ```
 
-The plugin jar is a self contained-jar, it is expected to contain the following inside it —
+The plugin jar is a self contained-jar. It is expected to contain the following inside it:
 
-* `plugin.xml` — the [metadata](#the-plugin-metadata) of your plugin
-* the [plugin extension class](#the-plugin-extension-class) (`<%= plugin_class %>.class` in the example shown) and any other classes that form your plugin
-* any optional [dependencies](#the-plugin-dependencies) your plugin may requires (inside the `lib`)
+* `plugin.xml` — The [metadata](#the-plugin-metadata) of your plugin.
+* The [plugin extension class](#the-plugin-extension-class) (`<%= plugin_class %>.class` in the example shown) and any other classes that form your plugin.
+* Any optional [dependencies](#the-plugin-dependencies) your plugin may requires (inside the `lib`).
 
 <a id='the-plugin-metadata'></a>
 
 ### The plugin metadata `plugin.xml`
 
-> Here is an example `plugin.xml`
+> Here is an example `plugin.xml`:
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
@@ -75,7 +75,7 @@ You can find the XML Schema for the plugins in the  [main repository](https://gi
 
 ### The plugin extension class
 
-> Add this to your maven `pom.xml`
+> Add this to your maven `pom.xml`:
 
 ```xml
 <dependency>
@@ -89,7 +89,7 @@ In order to use the plugin extension class, you must add the following to your m
 
 <div style='clear: both;'></div>
 
-> An example plugin class implementation
+> An example plugin class implementation:
 
 ```java
 package com.example.go.testplugin;
@@ -136,7 +136,7 @@ public class <%= plugin_class %> implements GoPlugin {
 
 The plugin extension class is a Java class that implements the `GoPlugin` interface.
 
-The other types in the example are —
+The other types in the example are:
 
 <p class='attributes-table-follows'></p>
 

--- a/source/includes/tasks/_021-task-configuration.md
+++ b/source/includes/tasks/_021-task-configuration.md
@@ -1,6 +1,6 @@
 ## Task Configuration
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/tasks/_022-task-view-in.md
+++ b/source/includes/tasks/_022-task-view-in.md
@@ -1,6 +1,6 @@
 ## Task View
 
-> An example response body
+> An example response body:
 
 ```json
 {

--- a/source/includes/tasks/_024-execute-task.md
+++ b/source/includes/tasks/_024-execute-task.md
@@ -1,6 +1,6 @@
 ## Execute Task
 
-> An example request body
+> An example request body:
 
 ```json
 {

--- a/source/partials/_describe_sub_object.md.erb
+++ b/source/partials/_describe_sub_object.md.erb
@@ -6,7 +6,7 @@
 <% unless object.__name.blank? -%>
 ### <%= object.__name %>
 
-> Here's an example of <%= object.__name.downcase %>
+> Here's an example of <%= object.__name.downcase %>:
 <% end -%>
 
 <% if !object.__options[:json].nil? %>


### PR DESCRIPTION
  - Use of periods, colons
  - Capitalization
  - Added an example for the analytics Transport object callbacks