### PR TITLE
Document the API version for all the application_accessor endpoints

### DIFF
--- a/source/includes/artifacts/_040-console-logs.md
+++ b/source/includes/artifacts/_040-console-logs.md
@@ -6,6 +6,10 @@ The plugin can send console logs to the server while fetching or publishing arti
 
 `go.processor.artifact.console-log`
 
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
+
 <p class='request-name-heading'>Request body</p>
 
 The request body must contain the logLevel and a message string. The logLevel must be `INFO` or `ERROR`.

--- a/source/includes/authorization/_041-invalidate-cache.md
+++ b/source/includes/authorization/_041-invalidate-cache.md
@@ -8,6 +8,10 @@ With authorization plugins a user is authenticated using an external authorizati
 
 `go.processor.authorization.invalidate-cache`
 
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
+
 <p class='request-body-heading'>Request body</p>
 
 The server will not parse a request body.

--- a/source/includes/elastic-agents/_051-list-agents.md
+++ b/source/includes/elastic-agents/_051-list-agents.md
@@ -51,6 +51,10 @@ This messages allows a plugin to query the server for a list of elastic agents t
 
 `go.processor.elastic-agents.list-agents`
 
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
+
 <p class='request-body-heading'>Request body</p>
 
 Can be left blank, the server does not parse the request body.

--- a/source/includes/elastic-agents/_052-disable-agents.md
+++ b/source/includes/elastic-agents/_052-disable-agents.md
@@ -52,6 +52,10 @@ Agents in any state can be disabled, this will prevent jobs from being assigned 
 
 `go.processor.elastic-agents.disable-agents`
 
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
+
 <p class='request-body-heading'>Request body</p>
 
 The body must contain a list of [agents](#elastic-agent-object).

--- a/source/includes/elastic-agents/_053-delete-agents.md
+++ b/source/includes/elastic-agents/_053-delete-agents.md
@@ -64,6 +64,10 @@ Before the delete-agent message is sent to the server, the plugin MUST ensure th
 
 `go.processor.elastic-agents.delete-agents`
 
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
+
 <p class='request-body-heading'>Request body</p>
 
 The body must contain a list of [agents](#elastic-agent-object) that should be removed from the config XML.

--- a/source/includes/notifications/_034-get-plugin-settings.md.erb
+++ b/source/includes/notifications/_034-get-plugin-settings.md.erb
@@ -1,1 +1,1 @@
-<%= partial 'includes/shared/get-plugin-settings.md.erb', locals: { plugin_class: 'ConsoleLogNotificationPlugin', plugin_type: 'notification', endpoint_version: '2.0' } %>
+<%= partial 'includes/shared/get-plugin-settings.md.erb', locals: { plugin_class: 'ConsoleLogNotificationPlugin', plugin_type: 'notification', endpoint_version: '1.0' } %>

--- a/source/includes/shared/_add-server-health-messages.erb
+++ b/source/includes/shared/_add-server-health-messages.erb
@@ -68,7 +68,9 @@ the newly specified messages (or cleared if the body is an empty list).
 
 Name: `go.processor.server-health.add-messages`
 
-Version: `1.0`
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
 
 <p class='request-body-heading'>Request body</p>
 

--- a/source/includes/shared/_get-plugin-settings.md.erb
+++ b/source/includes/shared/_get-plugin-settings.md.erb
@@ -56,6 +56,10 @@ This messages allows a plugin to query the server to get the user configured set
 
 `go.processor.plugin-settings.get`
 
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `<%= endpoint_version %>`.
+
 <p class='request-body-heading'>Request body</p>
 
 > An example request body:


### PR DESCRIPTION
* The API version for the application_accessor was not explicitly
  documented which lead to ambguity. Explicitly setting the API version
  for each accessor endpoint.
* Refer https://github.com/gocd/gocd/issues/5653