### PR TITLE
Adding new scm extension definition to docs

### DIFF
--- a/source/includes/config-repo/_021-parse-directory.md.erb
+++ b/source/includes/config-repo/_021-parse-directory.md.erb
@@ -234,6 +234,32 @@ The plugin is expected to return status `200` if it can understand the request.
           "location": "optional: key to group errors by"
         },
         {
+          "type": "plugin",
+          "plugin_configuration": {
+            "id": "some-plugin-id",
+            "version": "1",
+            "location": "optional: key to group errors by"
+          },
+          "configuration": [
+            {
+              "key": "url",
+              "value": "git@github.com:gocd/plugin-api.go.cd.git",
+              "encrypted_value": "encryptedValue1",
+              "location": "optional: key to group errors by"
+            }
+          ],
+          "destination": "scmDestinationDir",
+          "filter": {
+            "ignore": [
+              "dir1",
+              "dir2"
+            ],
+            "whitelist": []
+          },
+          "name": "myNewPluggableGitDefinition",
+          "location": "optional: key to group errors by"
+        },
+        {
           "type": "dependency",
           "pipeline": "pipeline2",
           "stage": "build",


### PR DESCRIPTION
https://github.com/gocd/plugin-api.go.cd/issues/93

Added it to the parse directory example. @arvindsv is there anymore documentation that needs to be added here?