### PR TITLE
Add documentation: Elastic agent plugins can log messages to console log

### DIFF
--- a/source/includes/changelog/_19-02-0.md.erb
+++ b/source/includes/changelog/_19-02-0.md.erb
@@ -1,26 +1,24 @@
-## Changes in 19.2.0
+## Changes in GoCD 19.2.0
 
-<h3 class="changelog-header">Added</h3>
+### Config repositories (Additions)
 
-### Config repositories
-- This version adds support for v2 for [Config repositories](config-repo). v2 of Config repositories adds the following new messages,
- - [Parse Content](config-repo#parse-content) 
- - [Pipeline Export](config-repo#pipeline-export) 
- - [Plugin Icon](config-repo#get-plugin-icon)
- - [Plugin Capabilities](config-repo#get-plugin-capabilities)
+  - Supports version 2 of [Config repositories](config-repo) extension API. Version 2 adds the following new messages:
+    - [Parse Content](config-repo#parse-content)
+    - [Pipeline Export](config-repo#pipeline-export)
+    - [Plugin Icon](config-repo#get-plugin-icon)
+    - [Plugin Capabilities](config-repo#get-plugin-capabilities)
 
-### Authorization
-- This version adds support for v2 for [Authorization Extension](authorization). v2 of authorization extension adds the following new messages,
- - [Is Valid User](authorization#is-valid-user)
- - [Get User Roles](authorization#get-user-roles)
+### Authorization (Additions)
 
-Plugins [Capabilities](authorization#get-plugin-capabilities) message is enhanced to add a new capablity `can_get_user_roles`.
+  - Supports version 2 of [Authorization](authorization) extension API. Version 2 adds the following new messages:
+    - [Is Valid User](authorization#is-valid-user)
+    - [Get User Roles](authorization#get-user-roles)
 
-<h3 class="changelog-header">Removed</h3>
+### Authorization (Changes)
 
-No removals this release.
+  - Plugins [Capabilities](authorization#get-plugin-capabilities) message is enhanced to add a new capablity `can_get_user_roles`.
 
-<h3 class="changelog-header">Deprecations</h3>
+### Deprecations (across extensions)
 
 - The elastic agent plugin extension version 3 has been deprecated. This version will be removed in a release scheduled for Mar 2019. Plugin developers should use version 4 of the elastic agent plugin api to allow adding support for job completion request. The docker, docker swarm, kubernetes and ecs plugins have been migrated to the new versions, and users should upgrade their plugins to the latest version to see these new features.
 - The notification plugin extension version 3 has been deprecated. This version will be removed in a release scheduled for Mar 2019. Plugin developers should use version 4 of the notification plugin api.

--- a/source/includes/changelog/_19-03-0.md.erb
+++ b/source/includes/changelog/_19-03-0.md.erb
@@ -1,18 +1,21 @@
-## Changes in 19.3.0
+## Changes in GoCD 19.3.0
 
-<h3 class="changelog-header">Added</h3>
+### Elastic Agents (Additions)
 
-### Elastic Agents
-- We have released a new version v5 of the [Elastic Agents](elastic-agents) extension. It introduces a new feature of multi cluster.
+We have released a new version v5 of the [Elastic Agents](elastic-agents) extension. It introduces a new feature of multi cluster support.
 
-#### New messages
+The new messages added are:
+
  - [Get Cluster Status Report](elastic-agents#get-cluster-status-report)
  - [Get Cluster Profile View](elastic-agents#get-cluster-profile-view)
  - [Get Cluster Profile Metadata](elastic-agents#get-cluster-profile-metadata)
  - [Validate Cluster Profile](elastic-agents#validate-cluster-profile)
  - [Migrate Config](elastic-agents#migrate-config)
 
-#### Changes in existing message
+### Elastic Agents (Changes)
+
+Endpoints defined in previous versions of this API have been enhanced, in the new version:
+
  - [Create Agent](elastic-agents#create-agent)
  - [Should Assign Work](elastic-agents#should-assign-work)
  - [Server Ping](elastic-agents#server-ping)
@@ -22,11 +25,7 @@
  - [Get Cluster Status Report](elastic-agents#get-cluster-status-report)
  - [Plugin Status Report](elastic-agents#get-plugin-status-report)
 
-<h3 class="changelog-header">Removed</h3>
-
-No removals this release.
-
-<h3 class="changelog-header">Deprecations</h3>
+### Deprecations (across extensions)
 
 - The elastic agent plugin extension version 4 has been deprecated. This version will be removed in a release scheduled for Mar 2019. Plugin developers should use version 5 of the elastic agent plugin api to allow adding support for multi cluster. The docker, docker swarm, kubernetes and ecs plugins have been migrated to the new versions, and users should upgrade their plugins to the latest version to see these new features.
 - The notification plugin extension version 3 has been deprecated. This version will be removed in a release scheduled for Mar 2019. Plugin developers should use version 4 of the notification plugin api.

--- a/source/includes/changelog/_19-04-0.md.erb
+++ b/source/includes/changelog/_19-04-0.md.erb
@@ -1,0 +1,8 @@
+## Changes in GoCD 19.4.0
+
+No additions and removals in this release.
+
+### Deprecations (across extensions)
+
+- The notification plugin extension version 3 has been deprecated. This version will be removed in an upcoming release. Plugin developers should use version 4 of the notification plugin api.
+- The analytics plugin extension version 1 has been deprecated. This version will be removed in an upcoming release. Plugin developers should use version 2 of the analytics plugin api.

--- a/source/includes/changelog/_19-05-0.md.erb
+++ b/source/includes/changelog/_19-05-0.md.erb
@@ -1,0 +1,11 @@
+## Changes in GoCD 19.5.0
+
+### Elastic Agents (Additions)
+
+A new message which can be sent from the plugin to the GoCD server has been added:
+
+ - [Log Message to Job Console](elastic-agents#log-messages-to-job-console): This allows an elastic agent plugin to log messages to the current job's console.
+
+### Deprecations (across extensions)
+
+No deprecations in this release.

--- a/source/includes/elastic-agents/_010-introduction.md.erb
+++ b/source/includes/elastic-agents/_010-introduction.md.erb
@@ -161,4 +161,4 @@ See the video linked below to help make this a little more clear.
   <%= image_tag 'elastic-agents/new-job-assignment.png', {:title => "Job assignment with elastic agents", :alt => "Job assignment with elastic agents"} %>
 </a>
 
-<%= partial 'includes/shared/plugin-structure.md.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '1.0', minimum_version: '16.8.0' } %>
+<%= partial 'includes/shared/plugin-structure.md.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '5.0', minimum_version: '16.8.0' } %>

--- a/source/includes/elastic-agents/_050-server-request-messages.md
+++ b/source/includes/elastic-agents/_050-server-request-messages.md
@@ -8,3 +8,4 @@ The plugin may make the following requests to the server using `GoApplicationAcc
 * [Get Plugin Settings](#get-plugin-settings)
 * [Get Server Info](#get-server-info)
 * [Add Server Health Messages](#add-server-health-messages)
+* [Log Message to Job Console](#log-messages-to-job-console)

--- a/source/includes/elastic-agents/_051-list-agents.md
+++ b/source/includes/elastic-agents/_051-list-agents.md
@@ -19,7 +19,7 @@ public class DockerPlugin implements GoPlugin {
   }
 
   public GoPluginIdentifier pluginIdentifier() {
-    return new GoPluginIdentifier("elastic-agent", Arrays.asList("1.0"))
+    return new GoPluginIdentifier("elastic-agent", Arrays.asList("5.0"))
   }
 
   private List listAgents() {

--- a/source/includes/elastic-agents/_052-disable-agents.md
+++ b/source/includes/elastic-agents/_052-disable-agents.md
@@ -19,7 +19,7 @@ public class DockerPlugin implements GoPlugin {
   }
 
   public GoPluginIdentifier pluginIdentifier() {
-    return new GoPluginIdentifier("elastic-agent", Arrays.asList("1.0"))
+    return new GoPluginIdentifier("elastic-agent", Arrays.asList("5.0"))
   }
 
   private disableAgents(List agents) {

--- a/source/includes/elastic-agents/_053-delete-agents.md
+++ b/source/includes/elastic-agents/_053-delete-agents.md
@@ -19,7 +19,7 @@ public class DockerPlugin implements GoPlugin {
   }
 
   public GoPluginIdentifier pluginIdentifier() {
-    return new GoPluginIdentifier("elastic-agent", Arrays.asList("1.0"))
+    return new GoPluginIdentifier("elastic-agent", Arrays.asList("5.0"))
   }
 
   private deleteAgents(List agents) {

--- a/source/includes/elastic-agents/_054-get-plugin-settings.md.erb
+++ b/source/includes/elastic-agents/_054-get-plugin-settings.md.erb
@@ -1,1 +1,1 @@
-<%= partial 'includes/shared/get-plugin-settings.md.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '1.0' } %>
+<%= partial 'includes/shared/get-plugin-settings.md.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '5.0' } %>

--- a/source/includes/elastic-agents/_056-add-server-health-messages.erb
+++ b/source/includes/elastic-agents/_056-add-server-health-messages.erb
@@ -1,1 +1,1 @@
-<%= partial 'includes/shared/add-server-health-messages.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '1.0', minimum_version: '16.8.0' } %>
+<%= partial 'includes/shared/add-server-health-messages.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '5.0', minimum_version: '16.8.0' } %>

--- a/source/includes/elastic-agents/_057-log-messages-to-job-console.erb
+++ b/source/includes/elastic-agents/_057-log-messages-to-job-console.erb
@@ -1,0 +1,1 @@
+<%= partial 'includes/shared/log-messages-to-job-console.erb', locals: { plugin_class: 'DockerElasticAgentPlugin', plugin_type: 'elastic-agent', endpoint_version: '5.0', minimum_version: '18.5.0' } %>

--- a/source/includes/shared/_add-server-health-messages.erb
+++ b/source/includes/shared/_add-server-health-messages.erb
@@ -64,9 +64,9 @@ the newly specified messages (or cleared if the body is an empty list).
 
 <%= available_since('18.3.0') %>
 
-<p class='request-name-heading'>Request</p>
+<p class='request-name-heading'>Request name</p>
 
-Name: `go.processor.server-health.add-messages`
+`go.processor.server-health.add-messages`
 
 <p class='request-body-heading'>Request version</p>
 

--- a/source/includes/shared/_log-messages-to-job-console.erb
+++ b/source/includes/shared/_log-messages-to-job-console.erb
@@ -1,0 +1,102 @@
+<h2 id="log-messages-to-job-console">Log Messages to Job Console</h2>
+
+```java
+import com.thoughtworks.go.plugin.api.*;
+import com.thoughtworks.go.plugin.api.annotation.Extension;
+import com.thoughtworks.go.plugin.api.logging.Logger;
+import com.thoughtworks.go.plugin.api.request.*;
+import com.thoughtworks.go.plugin.api.response.*;
+import com.google.gson.Gson;
+import java.util.*;
+
+@Extension
+public class <%= plugin_class %> implements GoPlugin {
+  private GoApplicationAccessor accessor;
+  public static final Logger LOG = Logger.getLoggerFor(<%= plugin_class %>.class);
+
+  public void initializeGoApplicationAccessor(GoApplicationAccessor accessor) {
+    this.accessor = accessor;
+  }
+
+  public GoPluginIdentifier pluginIdentifier() {
+    return new GoPluginIdentifier("<%= plugin_type %>", Arrays.asList("<%= endpoint_version %>"));
+  }
+
+  private void appendToConsoleLog(String text) throws ServerRequestFailedException {
+    Map<String, String> requestMap = new HashMap<>();
+    requestMap.put("pipelineName", "my_pipeline_1");
+    requestMap.put("pipelineCounter", "123");
+    requestMap.put("stageName", "stage1");
+    requestMap.put("stageCounter", "1");
+    requestMap.put("jobName", "job1");
+    requestMap.put("text", text);
+
+    DefaultGoApiRequest request = new DefaultGoApiRequest("go.processor.console-log.append", "1.0", pluginIdentifier());
+    request.setRequestBody(new GsonBuilder().create().toJson(requestMap));
+
+    GoApiResponse response = accessor.submit(request);
+
+    if (response.responseCode() != 200) {
+      LOG.error("Failed to append console log for " + jobIdentifier.represent() + " with text: " + text);
+    }
+  }
+}
+```
+
+This message allows a plugin to add messages to be shown in the GoCD job console.
+
+<%= available_since('19.5.0') %>
+
+<p class='request-name-heading'>Request name</p>
+
+`go.processor.console-log.append`
+
+<p class='request-body-heading'>Request version</p>
+
+The request version must be set to `1.0`.
+
+<p class='request-body-heading'>Request body</p>
+
+> An example request body:
+
+```json
+{
+  "pipelineName": "my_pipeline_1",
+  "pipelineCounter": "123",
+  "stageName": "stage1",
+  "stageCounter": "1",
+  "jobName": "job1",
+  "text": "Message to show in console log."
+}
+```
+
+Must be a JSON object made up of JSON elements as described below:
+
+<p class='attributes-table-follows'></p>
+
+| Key               | Type     | Description                                            |
+| ----------------- | -------- | ------------------------------------------------------ |
+| `pipelineName`    | `String` | Name of the pipeline in which the job is.              |
+| `pipelineCounter` | `String` | The pipeline counter (run counter of the pipeline).    |
+| `stageName`       | `String` | Name of the stage the job is in.                       |
+| `stageCounter`    | `String` | The run counter of the stage.                          |
+| `jobName`         | `String` | The name of the job.                                   |
+| `text`            | `String` | The message to be shows in the console log of the job. |
+
+
+<p class='response-code-heading'>Response code</p>
+
+The server is expected to return status `200` if it could process the request. It is expected to return status `500` if it failed to process the request.
+
+<p class='response-body-heading'>Response Body</p>
+
+> An example response body for a failure:
+
+```json
+{
+  "message": "An error occurred ..."
+}
+```
+
+The server will respond with a single JSON object with an error message with the key `message`, if it is unable to process the request. If
+successful, the response body will be empty.


### PR DESCRIPTION
For https://github.com/gocd/gocd/pull/6299

@GaneshSPatil I've set some elastic agent plugin identifier versions to `5.0`, since `1.0` is invalid at this time. Let me know if that's wrong and I should revert it. Thank you!

![Screenshot_2019-06-06 GoCD Elastic Agent Plugin API Reference](https://user-images.githubusercontent.com/172235/59057708-034f8f00-8869-11e9-8d4b-b3620ba3d7c4.png)
