### PR TITLE
fix name of artifact's metadata folder

### DIFF
--- a/source/includes/artifacts/_021-publish-artifact.md
+++ b/source/includes/artifacts/_021-publish-artifact.md
@@ -100,7 +100,7 @@ The plugin is expected to return status `200` if it can understand the request.
 
 <p class='response-body-heading'>Response Body</p>
 
-The plugin is expected to return a json as shown. This json is written into a file called `<plugin-id>.json` on the agent and uploaded as a `Build Artifact` to the GoCD server to a directory called `pluggable_metadata_folder`
+The plugin is expected to return a json as shown. This json is written into a file called `<plugin-id>.json` on the agent and uploaded as a `Build Artifact` to the GoCD server to a directory called `pluggable-artifact-metadata`. This directory is never removed as part of cleaning GoCD artifacts.
 
 > Plugin response body
 


### PR DESCRIPTION
`pluggable_metadata_folder` is just confusing. No such string/name exists in GoCD source code.
I think the point was to say where the json file is stored, which is `pluggable-artifact-metadata/<plugin-id>.json`.