### PR TITLE
Added link checker

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,7 @@
 source 'https://rubygems.org'
 
+gem 'html-proofer'
+
 # Middleman
 gem 'middleman', '~> 4.1.0'
 gem 'middleman-gh-pages', '~> 0.3.0'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -40,6 +40,8 @@ GEM
       eventmachine (>= 0.12.9)
       http_parser.rb (~> 0.6.0)
     erubis (2.7.0)
+    ethon (0.12.0)
+      ffi (>= 1.3.0)
     eventmachine (1.2.7)
     execjs (2.7.0)
     fast_blank (1.0.0)
@@ -51,6 +53,15 @@ GEM
     hamster (3.0.0)
       concurrent-ruby (~> 1.0)
     hashie (3.6.0)
+    html-proofer (3.11.1)
+      activesupport (>= 4.2, < 6.0)
+      addressable (~> 2.3)
+      mercenary (~> 0.3.2)
+      nokogiri (~> 1.9)
+      parallel (~> 1.3)
+      rainbow (~> 3.0)
+      typhoeus (~> 1.3)
+      yell (~> 2.0)
     http_parser.rb (0.6.0)
     i18n (0.7.0)
     jmespath (1.4.0)
@@ -59,6 +70,7 @@ GEM
       rb-fsevent (~> 0.9, >= 0.9.4)
       rb-inotify (~> 0.9, >= 0.9.7)
     memoist (0.16.0)
+    mercenary (0.3.6)
     middleman (4.1.14)
       coffee-script (~> 2.2)
       compass-import-once (= 1.0.5)
@@ -110,7 +122,10 @@ GEM
     mime-types (3.2.2)
       mime-types-data (~> 3.2015)
     mime-types-data (3.2019.0331)
+    mini_portile2 (2.4.0)
     minitest (5.11.3)
+    nokogiri (1.10.4)
+      mini_portile2 (~> 2.4.0)
     padrino-helpers (0.13.3.4)
       i18n (~> 0.6, >= 0.6.7)
       padrino-support (= 0.13.3.4)
@@ -122,6 +137,7 @@ GEM
     rack (2.0.7)
     rack-livereload (0.3.17)
       rack
+    rainbow (3.0.0)
     rake (12.3.3)
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
@@ -137,10 +153,13 @@ GEM
     thor (0.20.3)
     thread_safe (0.3.6)
     tilt (2.0.9)
+    typhoeus (1.3.1)
+      ethon (>= 0.9.0)
     tzinfo (1.2.5)
       thread_safe (~> 0.1)
     uglifier (3.2.0)
       execjs (>= 0.3.0, < 3)
+    yell (2.2.0)
 
 PLATFORMS
   ruby
@@ -148,6 +167,7 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
+  html-proofer
   listen (= 3.0.8)
   middleman (~> 4.1.0)
   middleman-autoprefixer (~> 2.10.1)

--- a/rakelib/static_checks.rake
+++ b/rakelib/static_checks.rake
@@ -1,0 +1,49 @@
+# coding: utf-8
+require 'nokogiri'
+require 'html-proofer'
+
+namespace :static_checks do
+  def should_not_run_external_url_checks?
+    if ENV['CI'] || ENV['SNAP_CI']
+      false
+    else
+      ENV['RUN_EXTERNAL_CHECKS'].nil? || ENV['RUN_EXTERNAL_CHECKS'] == 'false'
+    end
+  end
+
+  options = {
+      :disable_external     => should_not_run_external_url_checks?,
+      :url_ignore           => [/([https]:\/\/(localhost):*)|([a-z0-9:\/-]*:8154)|([a-z0-9:\/-]*:8153)|(your)|(svn)|([a-zA-z@:\/_]*.git)/],
+      :allow_hash_href      => true,
+      :allow_missing_href   => true,
+      :href_ignore          => ['/https:\/\/www\.youtube\.com\/.*/'],
+      :validation           => {
+          :report_invalid_tags  => false,
+          :report_script_embeds => false,
+          :report_missing_names => false ,
+      },
+      :external_only        => false ,
+      :check_html           => false,
+      :typhoeus => {
+          :ssl_verifypeer => false,
+      },
+      :empty_alt_ignore     => true,
+      :log_level            => :info
+  }
+
+  task :html_proofer do
+    STDERR.puts "WARNING: Not checking outbound links. Set environment variable: " +
+                    "RUN_EXTERNAL_CHECKS to 'true' to run them" if should_not_run_external_url_checks?
+
+    puts "\nRunning link checks, html format and verifying that it can be hosted in a subdirectory (relative links):"
+    Dir.mktmpdir do |tmpdir|
+      cp_r 'build/', File.join(tmpdir, 'subdir')
+
+      cd tmpdir do
+        HTMLProofer.check_directory('.', options).run
+      end
+    end
+  end
+
+  task :all => [:build, :html_proofer]
+end

--- a/source/includes/authorization/_020-request-from-server.md
+++ b/source/includes/authorization/_020-request-from-server.md
@@ -17,7 +17,7 @@ All Authorization plugins should implement the following messages to support aut
 If a plugin supports web based authentication, apart from the above, the plugin must implement the following messages. The plugin should use the `supported_auth_type` [capability](#get-plugin-capabilities) to expose this feature.
 
 * [Fetch Access Token](#fetch-access-token)
-* [Get Authorization Server Redirect URL](#authorization-server-redirect-url)
+* [Get Authorization Server Redirect URL](#authorization-server-url)
 
 For a plugin to support authorization, the following messages must be implemented. The plugin should use the `can_authorize` [capability](#get-plugin-capabilities) to expose this feature.
 

--- a/source/includes/config-repo/_050-object-descriptions.md.erb
+++ b/source/includes/config-repo/_050-object-descriptions.md.erb
@@ -1,3 +1,17 @@
 # Request/Response JSON Objects
 
 <%= partial 'includes/shared/plugin-settings-request-response-json-objects.md.erb' %>
+
+<%
+image = {
+  'content_type' => 'image/svg+xml',
+  'data' => '....'
+}
+%>
+
+<%=
+describe_sub_object 'The Image Object', json: image, html_id: 'the-image-object' do
+  content_type 'String', 'A valid [content type](http://www.iana.org/assignments/media-types/media-types.xhtml#image) for the image. Please make sure the content type is supported by most browsers.'
+  data         'String', "A [base-64](https://en.wikipedia.org/wiki/Base64) encoded (single-line non-chunking) byte array of the byte-sequence that composes the image."
+end
+%>

--- a/source/includes/shared/_plugin-structure.md.erb
+++ b/source/includes/shared/_plugin-structure.md.erb
@@ -142,7 +142,11 @@ The other types in the example are:
 
 | Type                    | Description |
 | ----------------------- | ----------- |
+<% if !defined?(send_req_to_server) || send_req_to_server==true %>
 | [`GoApplicationAccessor`](#requests-to-the-gocd-server) | So that the plugin can make requests to the GoCD application to get additional information that is not provided by each request. For example, the plugin can ask for settings, credentials etc. |
+<% else %>
+| `GoApplicationAccessor` | So that the plugin can make requests to the GoCD application to get additional information that is not provided by each request. For example, the plugin can ask for settings, credentials etc. (`<%=plugin_type.capitalize %>` plugins do not send any request to the server.) |
+<% end %>
 | `GoPluginIdentifier`    | Provides information about the type of plugin and the version of the request/response it supports. |
 | `GoPluginApiRequest`    | Represents the request message sent from GoCD to a plugin. The message will have a name and an optional JSON request body and the version of the extension. |
 | `GoPluginApiResponse`   | Represents the response message as a result of processing the `GoPluginApiRequest`. Similar to `GoPluginApiRequest`, the response will have a status code and an optional JSON response body. |

--- a/source/includes/tasks/_010-introduction.md.erb
+++ b/source/includes/tasks/_010-introduction.md.erb
@@ -4,4 +4,4 @@ The Task extension endpoint allows plugin authors to extend GoCD to run new task
 
 If you're looking to start away with a basic template for task plugins, we recommend forking this [github repository](https://github.com/gocd-contrib/task-skeleton-plugin).
 
-<%= partial 'includes/shared/plugin-structure.md.erb', locals: { plugin_class: 'EchoTaskPlugin', plugin_type: 'task', endpoint_version: '1.0', minimum_version: '15.1.0' } %>
+<%= partial 'includes/shared/plugin-structure.md.erb', locals: { plugin_class: 'EchoTaskPlugin', plugin_type: 'task', endpoint_version: '1.0', minimum_version: '15.1.0', send_req_to_server:false } %>


### PR DESCRIPTION
- fixed broken links
- added a flag `send_req_to_server` for `_plugin-structure.md.erb` so that the `GoApplicationAccessor` links to the request to server only if required.
 E.g. `task` does not send any requests to the server - hence link was broken. 

<img width="705" alt="Screen Shot 2019-08-27 at 10 08 29 AM" src="https://user-images.githubusercontent.com/41165891/63741543-28293080-c8b3-11e9-8e73-64383c71a83d.png">
