### PR TITLE
Fix artifact plugin version to v2

### DIFF
--- a/source/includes/artifacts/_010-introduction.md.erb
+++ b/source/includes/artifacts/_010-introduction.md.erb
@@ -2,7 +2,7 @@
 
 ## Current Version
 
-This document is for version 1.0 (the latest) of the artifacts endpoint.
+This document is for version 2.0 (the latest) of the artifacts endpoint.
 
 ## Background
 

--- a/source/includes/artifacts/_022-fetch-artifact.md
+++ b/source/includes/artifacts/_022-fetch-artifact.md
@@ -1,5 +1,14 @@
 ## Fetch Artifact
 
+This message is a request to the plugin to fetch an artifact from the specified artifact store.
+
+<p class='request-name-heading'>Request name</p>
+
+`cd.go.artifact.fetch-artifact`
+
+<p class='request-body-heading'>Request body</p>
+
+
 > Given the following config XML snippet —
 
 ```xml
@@ -81,14 +90,6 @@
   "agent_working_directory":"/Users/varshavs/gocd/agent/pipelines/build"
 }
 ```
-
-This message is a request to the plugin to fetch an artifact from the specified artifact store.
-
-<p class='request-name-heading'>Request name</p>
-
-`cd.go.artifact.fetch-artifact`
-
-<p class='request-body-heading'>Request body</p>
 
 The request body will contain the following JSON elements:
 


### PR DESCRIPTION
The artifact plugin version should be 2.0. The bump was made when there were changes were in Fetch Artifact response to return environment variables (which is already documented).

Also modified the layout a bit so that the Fetch Artifact section doesn't look empty.
Before:
<img width="1205" alt="Screenshot 2019-10-21 at 15 31 14" src="https://user-images.githubusercontent.com/6024038/67196169-e7174d80-f417-11e9-84d5-f7c955c589be.png">

After:
<img width="1209" alt="Screenshot 2019-10-21 at 15 30 51" src="https://user-images.githubusercontent.com/6024038/67196184-f0081f00-f417-11e9-985e-66a46433f7ae.png">

If this change seems ok, I can backport it. The Api V2 was introduced in 18.10 or 18.11 as per [this commit](https://github.com/gocd/gocd/commit/7203cb371a2ce06a18a7bbc5c2a317cd93a074cf)