### PR TITLE
Fix typo in plugin status report documentation

### DIFF
--- a/source/includes/elastic-agents/_037-get-plugin-status-report.md.erb
+++ b/source/includes/elastic-agents/_037-get-plugin-status-report.md.erb
@@ -69,7 +69,7 @@ If plugin supports the plugin status report, this message must be implemented to
 
 | Key                              | Type     | Description                                                       |
 | -------------------------------- | -------- | -----------                                                       |
-| `all_cluster_profile_properties` | `Array`  | The field represents the list of cluster profiles for the plugin. |
+| `all_cluster_profiles_properties` | `Array`  | The field represents the list of cluster profiles for the plugin. |
 
 <p class='response-code-heading'>Response code</p>
 


### PR DESCRIPTION
It's acutally a small bug in the implementation. The field _should_ be called `all_cluster_profile_properties` and not `all_cluster_profiles_properties`. But, since it is the way it is, at least the documentation should reflect it.